### PR TITLE
More cleanup and further work on issue 129

### DIFF
--- a/captive_portal/captive_portal.py
+++ b/captive_portal/captive_portal.py
@@ -188,9 +188,10 @@ class CaptivePortal(object):
         # Assemble some HTML to redirect the client to the captive portal's
         # /index.html-* page.
         #
-        # We are using eth0 here for the address - this may or may not be
-        # right, but since
-        redirect = """<html><head><meta http-equiv="refresh" content="0; url=http://""" + get_ip_address("eth0") + """/" /></head> <body></body> </html>"""
+        # We are using wlan0:1 here for the address - this may or may not be
+        # right, but since we can't get at self.args.address it's the best we
+        # can do.
+        redirect = """<html><head><meta http-equiv="refresh" content="0; url=http://""" + get_ip_address("wlan0:1") + """/" /></head> <body></body> </html>"""
 
         logging.debug("Generated HTML refresh is:")
         logging.debug(redirect)

--- a/captive_portal/captive_portal.py
+++ b/captive_portal/captive_portal.py
@@ -139,8 +139,7 @@ class CaptivePortal(object):
         # Set up the command string to add the client to the IP tables ruleset.
         addclient = ['/usr/local/sbin/captive-portal.sh', 'add', clientip]
         if self.args.test:
-            print "Command that would be executed:"
-            print str(addclient)
+            logging.debug("Command that would be executed:\n%s", addclient)
         else:
             subprocess.call(addclient)
 
@@ -307,7 +306,7 @@ def setup_iptables(args):
                            args.address, args.interface]
     iptables = 0
     if args.test:
-        print "Command that would be executed:"
+        logging.debug("Command that would be executed:\n%s", ' '.join(initialize_iptables))
         print str(initialize_iptables)
     else:
         iptables = subprocess.call(initialize_iptables)
@@ -320,8 +319,7 @@ def setup_reaper(test):
                           '-i', '60']
     reaper = 0
     if test:
-        print "Idle client monitor command that would be executed:"
-        print str(idle_client_reaper)
+        logging.debug("Idle client monitor command that would be executed:\n%s", ' '.join(idle_client_reaper))
     else:
         logging.debug("Starting mop_up_dead_clients.py.")
         reaper = subprocess.Popen(idle_client_reaper)
@@ -335,8 +333,7 @@ def setup_hijacker(args):
     dns_hijacker = ['/usr/local/sbin/fake_dns.py', args.address]
     hijacker = 0
     if args.test:
-        print "Command that would start the fake DNS server:"
-        print str(dns_hijacker)
+        logging.debug("Command that would start the fake DNS server:\n%s", ' '.join(dns_hijacker))
     else:
         logging.debug("Starting fake_dns.py.")
         hijacker = subprocess.Popen(dns_hijacker)

--- a/control_panel/_utils.py
+++ b/control_panel/_utils.py
@@ -16,7 +16,7 @@ def str2file(string,file_name,mode = 'w'):
 	fileobj.write(string)
 	fileobj.close()
 
-class config:
+class Config(object):
 	''' Make me read from a file '''
 	def __init__(self):
 		self.services_cache = '/tmp/byz_services.json'

--- a/control_panel/avahiutil.py
+++ b/control_panel/avahiutil.py
@@ -1,8 +1,8 @@
 import os.path
-from _utils import *
+import _utils
 
-services_store_dir = config().services_store_dir
-services_live_dir = config().services_live_dir
+services_store_dir = _utils.Config().services_store_dir
+services_live_dir = _utils.Config().services_live_dir
 
 
 def _mksname(name):
@@ -38,7 +38,7 @@ def add(name,port,host = '',domain = '',stype = '_http._tcp',subtype = None,prot
 	for i in text:
 		stext += '<text-record>'+i.strip()+'</text-record>'
 	service_conf = service_tmpl % {'name':name,'port':port,'host':host,'domain':domain,'stype':stype,'subtype':subtype or '','protocol':protocol or 'any','text':stext}
-	str2file(service_conf, service_path)
+	_utils.str2file(service_conf, service_path)
 	# activate here?
 
 def activate(name):

--- a/control_panel/control_panel.py
+++ b/control_panel/control_panel.py
@@ -62,7 +62,7 @@ def check_args(args):
 
 def main():
     args = check_args(parse_args())
-    if args.debug:
+    if args.debug or args.test:
         logging.basicConfig(level=logging.DEBUG)
     else:
         logging.basicConfig(level=logging.ERROR)

--- a/control_panel/gateways.py
+++ b/control_panel/gateways.py
@@ -121,7 +121,7 @@ class Gateways(object):
         if procnetdev:
             logging.debug("Successfully opened /proc/net/dev.")
         else:
-                # Note: This means that we use the contents of the database.
+            # Note: This means that we use the contents of the database.
             logging.debug("Warning: Unable to open /proc/net/dev.")
             return
 

--- a/control_panel/gateways.py
+++ b/control_panel/gateways.py
@@ -48,10 +48,10 @@ class Gateways(object):
         if self.test:
             # self.netconfdb = '/home/drwho/network.sqlite'
             self.netconfdb = 'var/db/controlpanel/network.sqlite'
-            print "TEST: Location of Gateways.netconfdb: %s" % self.netconfdb
+            logging.debug("Location of Gateways.netconfdb: %s", self.netconfdb)
             # self.meshconfdb = '/home/drwho/mesh.sqlite'
             self.meshconfdb = 'var/db/controlpanel/mesh.sqlite'
-            print "TEST: Location of Gateways.meshconfdb: %s" % self.meshconfdb
+            logging.debug("Location of Gateways.meshconfdb: %s", self.meshconfdb)
         else:
             self.netconfdb = '/var/db/controlpanel/network.sqlite'
             self.meshconfdb = '/var/db/controlpanel/mesh.sqlite'
@@ -143,7 +143,7 @@ class Gateways(object):
         # the interfaces.
         interfaces = []
         if self.test:
-            print "TEST: Pretending to harvest /proc/net/dev for network interfaces.  Actually using the contents of %s and loopback." % self.netconfdb
+            logging.debug("Pretending to harvest /proc/net/dev for network interfaces.  Actually using the contents of %s and loopback.", self.netconfdb)
             return
         else:
             for line in procnetdev:
@@ -307,16 +307,14 @@ class Gateways(object):
             command = ['/sbin/iwconfig', interface, 'essid', self.essid]
             logging.debug("Setting ESSID to %s.", self.essid)
             if self.test:
-                print "TEST: Command to set ESSID:"
-                print str(command)
+                logging.debug("Command to set ESSID:\n%s", ' '.join(command))
             else:
                 subprocess.Popen(command)
         if self.channel:
             command = ['/sbin/iwconfig', interface, 'channel', self.channel]
             logging.debug("Setting channel %s.", self.channel)
             if self.test:
-                print "TEST: Command to set channel:"
-                print str(command)
+                logging.debug("Command to set channel:\n%s", ' '.join(command))
             else:
                 subprocess.Popen(command)
 
@@ -328,9 +326,8 @@ class Gateways(object):
         command = ['/usr/local/sbin/gateway.sh', interface]
         logging.debug("Preparing to configure interface %s.", interface)
         if self.test:
-            print "TEST: Pretending to run gateway.sh on interface %s." % interface
-            print "TEST: Command that would be run:"
-            print str(command)
+            logging.debug("Pretending to run gateway.sh on interface %s.", interface)
+            logging.debug("Command that would be run:\n%s", ' '.join(command))
         else:
             process = subprocess.Popen(command)
 

--- a/control_panel/gateways.py
+++ b/control_panel/gateways.py
@@ -382,8 +382,8 @@ class Gateways(object):
         # network interface.  Full steam ahead, damn the torpedoes!
 
         # First, take the wireless NIC offline so its mode can be changed.
-        command = '/sbin/ifconfig ' + self.mesh_interface + ' down'
-        output = os.popen(command)
+        command = ['/sbin/ifconfig', self.mesh_interface, 'down']
+        output = subprocess.popen(command)
         time.sleep(5)
 
         # Wrap this whole process in a loop to ensure that stubborn wireless
@@ -392,16 +392,16 @@ class Gateways(object):
         # we can go on.
         while True:
             # Set the mode, ESSID and channel.
-            command = '/sbin/iwconfig ' + self.mesh_interface + ' mode ad-hoc'
-            output = os.popen(command)
-            command = '/sbin/iwconfig ' + self.mesh_interface + ' essid ' + self.essid
-            output = os.popen(command)
-            command = '/sbin/iwconfig ' + self.mesh_interface + ' channel ' + self.channel
-            output = os.popen(command)
+            command = ['/sbin/iwconfig', self.mesh_interface, 'mode ad-hoc']
+            output = subprocess.popen(command)
+            command = ['/sbin/iwconfig', self.mesh_interface, 'essid', self.essid]
+            output = subprocess.popen(command)
+            command = ['/sbin/iwconfig', self.mesh_interface, 'channel',  self.channel]
+            output = subprocess.popen(command)
 
             # Run iwconfig again and capture the current wireless configuration.
-            command = '/sbin/iwconfig ' + self.mesh_interface
-            output = os.popen(command)
+            command = ['/sbin/iwconfig', self.mesh_interface]
+            output = subprocess.popen(command)
             configuration = output.readlines()
 
             # Test the interface by going through the captured text to see if
@@ -435,14 +435,14 @@ class Gateways(object):
             break
 
         # Call ifconfig and set up the network configuration information.
-        command = '/sbin/ifconfig ' + self.mesh_interface + ' ' + self.mesh_ip
-        command = command + ' netmask ' + self.mesh_netmask + ' up'
-        output = os.popen(command)
+        command = ['/sbin/ifconfig', self.mesh_interface, self.mesh_ip,
+                   'netmask', self.mesh_netmask, 'up']
+        output = subprocess.popen(command)
         time.sleep(5)
 
         # Add the client interface.
-        command = '/sbin/ifconfig ' + self.client_interface + ' ' + self.client_ip + ' up'
-        output = os.popen(command)
+        command = ['/sbin/ifconfig', self.client_interface, self.client_ip, 'up']
+        output = subprocess.popen(command)
 
         # Commit the interface's configuration to the database.
         connection = sqlite3.connect(self.netconfdb)

--- a/control_panel/gateways.py
+++ b/control_panel/gateways.py
@@ -383,7 +383,7 @@ class Gateways(object):
 
         # First, take the wireless NIC offline so its mode can be changed.
         command = ['/sbin/ifconfig', self.mesh_interface, 'down']
-        output = subprocess.popen(command)
+        output = subprocess.Popen(command)
         time.sleep(5)
 
         # Wrap this whole process in a loop to ensure that stubborn wireless
@@ -393,15 +393,15 @@ class Gateways(object):
         while True:
             # Set the mode, ESSID and channel.
             command = ['/sbin/iwconfig', self.mesh_interface, 'mode ad-hoc']
-            output = subprocess.popen(command)
+            output = subprocess.Popen(command)
             command = ['/sbin/iwconfig', self.mesh_interface, 'essid', self.essid]
-            output = subprocess.popen(command)
+            output = subprocess.Popen(command)
             command = ['/sbin/iwconfig', self.mesh_interface, 'channel',  self.channel]
-            output = subprocess.popen(command)
+            output = subprocess.Popen(command)
 
             # Run iwconfig again and capture the current wireless configuration.
             command = ['/sbin/iwconfig', self.mesh_interface]
-            output = subprocess.popen(command)
+            output = subprocess.Popen(command)
             configuration = output.readlines()
 
             # Test the interface by going through the captured text to see if
@@ -437,12 +437,12 @@ class Gateways(object):
         # Call ifconfig and set up the network configuration information.
         command = ['/sbin/ifconfig', self.mesh_interface, self.mesh_ip,
                    'netmask', self.mesh_netmask, 'up']
-        output = subprocess.popen(command)
+        output = subprocess.Popen(command)
         time.sleep(5)
 
         # Add the client interface.
         command = ['/sbin/ifconfig', self.client_interface, self.client_ip, 'up']
-        output = subprocess.popen(command)
+        output = subprocess.Popen(command)
 
         # Commit the interface's configuration to the database.
         connection = sqlite3.connect(self.netconfdb)

--- a/control_panel/meshconfiguration.py
+++ b/control_panel/meshconfiguration.py
@@ -55,10 +55,10 @@ class MeshConfiguration(object):
         if self.test:
             # self.netconfdb = '/home/drwho/network.sqlite'
             self.netconfdb = 'var/db/controlpanel/network.sqlite'
-            print "TEST: Location of netconfdb: %s" % self.netconfdb
+            logging.debug("Location of netconfdb: %s", self.netconfdb)
             # self.meshconfdb = '/home/drwho/mesh.sqlite'
             self.meshconfdb = 'var/db/controlpanel/mesh.sqlite'
-            print "TEST: Location of meshconfdb: %s" % self.meshconfdb
+            logging.debug("Location of meshconfdb: %s", self.meshconfdb)
         else:
             self.netconfdb = '/var/db/controlpanel/network.sqlite'
             self.meshconfdb = '/var/db/controlpanel/mesh.sqlite'
@@ -225,7 +225,7 @@ class MeshConfiguration(object):
         babeld_command.append(self.babeld)
         babeld_command = babeld_command + common_babeld_opts
         babeld_command = babeld_command + unique_babeld_opts + interfaces
-        logging.debug("babeld command to be executed: %s", babeld_command)
+        logging.debug("babeld command to be executed: %s", ' '.join(babeld_command))
 
         # Test to see if babeld is running.  If it is, it's routing for at
         # least one interface, in which case we add the one the user just
@@ -234,13 +234,13 @@ class MeshConfiguration(object):
         pid = self.pid_check()
         if pid:
             if self.test:
-                print "TEST: Pretending to kill babeld."
+                logging.debug("Pretending to kill babeld.")
             else:
                 logging.debug("Killing current instance of babeld...")
                 os.kill(int(pid), signal.SIGTERM)
             time.sleep(self.babeld_timeout)
         if self.test:
-            print "TEST: Pretending to restart babeld."
+            logging.debug("Pretending to restart babeld.")
         else:
             logging.debug("Restarting babeld.")
             subprocess.Popen(babeld_command)
@@ -256,7 +256,7 @@ class MeshConfiguration(object):
             if not os.path.isdir(procdir):
                 error = "ERROR: babeld is not running!  Did it crash after startup?"
             else:
-                output = self.babeld + " has been successfully started with PID " + pid + "."
+                output = "%s has been successfully started with PID %s." % (self.babeld, pid)
 
                 # Update the mesh configuration database to take into account
                 # the presence of the new interface.
@@ -338,14 +338,14 @@ class MeshConfiguration(object):
         babeld_command.append(self.babeld)
         babeld_command = babeld_command + common_babeld_opts
         babeld_command = babeld_command + unique_babeld_opts + interfaces
-        logging.debug("New invocation of babeld: %s", babeld_command)
+        logging.debug("New invocation of babeld: %s", ' '.join(babeld_command))
 
         # Test to see if babeld is running.  If it is, we restart it without
         # the network interface that the user wants to drop out of the mesh.
         pid = self.pid_check()
         if pid:
             if self.test:
-                print "TEST: Pretending to kill babeld."
+                logging.debug("Pretending to kill babeld.")
             else:
                 logging.debug("Killing babeld.")
                 os.kill(int(pid), signal.SIGTERM)
@@ -356,7 +356,7 @@ class MeshConfiguration(object):
         if len(interfaces):
             logging.debug("value of babeld_command is %s", babeld_command)
             if self.test:
-                print "TEST: Pretending to restart babeld."
+                logging.debug("Pretending to restart babeld.")
             else:
                 subprocess.Popen(babeld_command)
             time.sleep(self.babeld_timeout)
@@ -370,7 +370,7 @@ class MeshConfiguration(object):
             if not os.path.isdir(procdir):
                 error = "ERROR: babeld is not running!  Did it crash during startup?"
             else:
-                output = self.babeld + " has been successfully started with PID " + pid + "."
+                output = "%s has been successfully started with PID %s" % (self.babeld, pid)
                 # Update the mesh configuration database to take into account
                 # the presence of the new interface.
                 template = ('yes', self.interface, )

--- a/control_panel/networkconfiguration.py
+++ b/control_panel/networkconfiguration.py
@@ -315,11 +315,11 @@ class NetworkConfiguration(object):
             logging.debug("Activating wireless interface.")
 
             # Note that arping returns '2' if the interface isn't online!
-            command = '/sbin/ifconfig ' + self.mesh_interface + ' up'
+            command = ['/sbin/ifconfig', self.mesh_interface, 'up']
             if self.test:
                 logging.debug("NetworkConfiguration.tcpip() command to activate network interface is %s.", command)
             else:
-                os.popen(command)
+                subprocess.Popen(command)
 
             # Sleep five seconds to give the hardware a chance to catch up.
             time.sleep(5)
@@ -412,7 +412,7 @@ class NetworkConfiguration(object):
             if self.test:
                 logging.debug("NetworkConfiguration.tcpip() command to deactivate a mesh interface: %s", command)
             else:
-                subprocess.popen(command)
+                subprocess.Popen(command)
 
         # Close the database connection.
         connection.close()
@@ -450,7 +450,7 @@ class NetworkConfiguration(object):
         if self.test:
             logging.debug("NetworkConfiguration.set_ip() command to deactivate a wireless interface: %s", command)
         else:
-            subprocess.popen(command)
+            subprocess.Popen(command)
         time.sleep(5)
 
         # Wrap this whole process in a loop to ensure that stubborn wireless
@@ -466,7 +466,7 @@ class NetworkConfiguration(object):
             if self.test:
                 logging.debug("NetworkConfiguration.set_ip() command to activate ad-hoc mode: %s", command)
             else:
-                subprocess.popen(command)
+                subprocess.Popen(command)
                 time.sleep(1)
 
             # Set ESSID.
@@ -475,7 +475,7 @@ class NetworkConfiguration(object):
             if self.test:
                 logging.debug("NetworkConfiguration.set_ip() command to set the ESSID: %s", command)
             else:
-                subprocess.popen(command)
+                subprocess.Popen(command)
                 time.sleep(1)
 
             # Set BSSID.
@@ -484,7 +484,7 @@ class NetworkConfiguration(object):
             if self.test:
                 logging.debug("NetworkConfiguration.set_ip() command to set the BSSID: %s", command)
             else:
-                subprocess.popen(command)
+                subprocess.Popen(command)
                 time.sleep(1)
 
             # Set wireless channel.
@@ -493,16 +493,16 @@ class NetworkConfiguration(object):
             if self.test:
                 logging.debug("NetworkConfiguration.set_ip() command to set the channel: %s", command)
             else:
-                subprocess.popen(command)
+                subprocess.Popen(command)
                 time.sleep(1)
 
             # Run iwconfig again and capture the current wireless configuration.
-            command = '/sbin/iwconfig ' + self.mesh_interface
+            command = ['/sbin/iwconfig', self.mesh_interface]
             configuration = ''
             if self.test:
                 logging.debug("NetworkConfiguration.set_ip()command to capture the current state of a network interface: %s", command)
             else:
-                output = os.popen(command)
+                output = subprocess.Popen(command, stdout=subprocess.PIPE).stdout
                 configuration = output.readlines()
 
             break_flag = False
@@ -566,7 +566,7 @@ class NetworkConfiguration(object):
         if self.test:
             logging.debug("NetworkConfiguration.set_ip()command to set the IP configuration of the mesh interface: %s", command)
         else:
-            subprocess.popen(command)
+            subprocess.Popen(command)
         time.sleep(5)
 
         # Add the client interface.
@@ -575,7 +575,7 @@ class NetworkConfiguration(object):
         if self.test:
             logging.debug("NetworkConfiguration.set_ip()command to set the IP configuration of the client interface: %s", command)
         else:
-            subprocess.popen(command)
+            subprocess.Popen(command)
 
         # Commit the interface's configuration to the database.
         connection = sqlite3.connect(self.netconfdb)

--- a/control_panel/networkconfiguration.py
+++ b/control_panel/networkconfiguration.py
@@ -60,7 +60,7 @@ def enumerate_network_interfaces():
     # interfaces into wired and wireless.
     for i in interfaces:
         logging.debug("Adding network interface %s.", i)
-        if os.path.isdir('/sys/class/net/' + i + '/wireless'):
+        if os.path.isdir("/sys/class/net/%s/wireless" % i):
             wireless.append(i)
         else:
             wired.append(i)
@@ -87,7 +87,7 @@ class NetworkConfiguration(object):
         if self.test:
             # self.netconfdb = '/home/drwho/network.sqlite'
             self.netconfdb = 'var/db/controlpanel/network.sqlite'
-            print "TEST: Location of NetworkConfiguration.netconfdb: %s" % self.netconfdb
+            logging.debug("Location of NetworkConfiguration.netconfdb: %s", self.netconfdb)
         else:
             self.netconfdb = '/var/db/controlpanel/network.sqlite'
 
@@ -128,8 +128,8 @@ class NetworkConfiguration(object):
         wired = []
         wireless = []
         (wired, wireless) = enumerate_network_interfaces()
-        logging.debug("Contents of wired[]: %s", str(wired))
-        logging.debug("Contents of wireless[]: %s", str(wireless))
+        logging.debug("Contents of wired[]: %s", wired)
+        logging.debug("Contents of wireless[]: %s", wireless)
 
         # MOOF MOOF MOOF - call to stub implementation.  We can use the list
         # immediately above (interfaces) as the list to compare the database
@@ -317,7 +317,7 @@ class NetworkConfiguration(object):
             # Note that arping returns '2' if the interface isn't online!
             command = '/sbin/ifconfig ' + self.mesh_interface + ' up'
             if self.test:
-                print "NetworkConfiguration.tcpip() command to activate network interface is %s." % command
+                logging.debug("NetworkConfiguration.tcpip() command to activate network interface is %s.", command)
             else:
                 os.popen(command)
 
@@ -346,7 +346,7 @@ class NetworkConfiguration(object):
             arping = ['/sbin/arping', '-c 5', '-D', '-f', '-q', '-I',
                       self.mesh_interface, addr]
             if self.test:
-                print "NetworkConfiguration.tcpip() command to probe for a mesh interface IP address is %s" % arping
+                logging.debug("NetworkConfiguration.tcpip() command to probe for a mesh interface IP address is %s", ' '.join(arping))
                 time.sleep(5)
             else:
                 ip_in_use = subprocess.call(arping)
@@ -359,7 +359,7 @@ class NetworkConfiguration(object):
 
             # In test mode, don't let this turn into an endless loop.
             if self.test:
-                print "Breaking out of this loop to exercise the rest of the code."
+                logging.debug("Breaking out of this loop to exercise the rest of the code.")
                 break
 
         # Next pick a distinct IP address for the client interface and its
@@ -383,7 +383,7 @@ class NetworkConfiguration(object):
             arping = ['/sbin/arping', '-c 5', '-D', '-f', '-q', '-I',
                       str(self.mesh_interface), addr]
             if self.test:
-                print "NetworkConfiguration.tcpip() command to probe for a client interface IP address is %s" % arping
+                logging.debug("NetworkConfiguration.tcpip() command to probe for a client interface IP address is %s", ' '.join(arping))
                 time.sleep(5)
             else:
                 ip_in_use = subprocess.call(arping)
@@ -396,7 +396,7 @@ class NetworkConfiguration(object):
 
             # In test mode, don't let this turn into an endless loop.
             if self.test:
-                print "Breaking out of this loop to exercise the rest of the code."
+                logging.debug("Breaking out of this loop to exercise the rest of the code.")
                 break
 
         # For testing, hardcode some IP addresses so the rest of the code has
@@ -410,7 +410,7 @@ class NetworkConfiguration(object):
             logging.debug("Deactivating wireless interface.")
             command = '/sbin/ifconfig ' + self.mesh_interface + ' down'
             if self.test:
-                print "NetworkConfiguration.tcpip() command to deactivate a mesh interface: %s" % command
+                logging.debug("NetworkConfiguration.tcpip() command to deactivate a mesh interface: %s", command)
             else:
                 os.popen(command)
 
@@ -448,7 +448,7 @@ class NetworkConfiguration(object):
         logging.debug("Deactivating wireless interface.")
         command = '/sbin/ifconfig ' + self.mesh_interface + ' down'
         if self.test:
-            print "NetworkConfiguration.set_ip() command to deactivate a wireless interface: %s" % command
+            logging.debug("NetworkConfiguration.set_ip() command to deactivate a wireless interface: %s", command)
         else:
             os.popen(command)
         time.sleep(5)
@@ -464,7 +464,7 @@ class NetworkConfiguration(object):
             logging.debug("Configuring wireless interface for ad-hoc mode.")
             command = '/sbin/iwconfig ' + self.mesh_interface + ' mode ad-hoc'
             if self.test:
-                print "NetworkConfiguration.set_ip() command to activate ad-hoc mode: %s" % command
+                logging.debug("NetworkConfiguration.set_ip() command to activate ad-hoc mode: %s", command)
             else:
                 os.popen(command)
                 time.sleep(1)
@@ -473,7 +473,7 @@ class NetworkConfiguration(object):
             logging.debug("Configuring ESSID of wireless interface.")
             command = '/sbin/iwconfig ' + self.mesh_interface + ' essid ' + self.essid
             if self.test:
-                print "NetworkConfiguration.set_ip() command to set the ESSID: %s" % command
+                logging.debug("NetworkConfiguration.set_ip() command to set the ESSID: %s", command)
             else:
                 os.popen(command)
                 time.sleep(1)
@@ -482,7 +482,7 @@ class NetworkConfiguration(object):
             logging.debug("Configuring BSSID of wireless interface.")
             command = '/sbin/iwconfig ' + self.mesh_interface + ' ap ' + self.bssid
             if self.test:
-                print "NetworkConfiguration.set_ip() command to set the BSSID: %s" % command
+                logging.debug("NetworkConfiguration.set_ip() command to set the BSSID: %s", command)
             else:
                 os.popen(command)
                 time.sleep(1)
@@ -491,7 +491,7 @@ class NetworkConfiguration(object):
             logging.debug("Configuring channel of wireless interface.")
             command = '/sbin/iwconfig ' + self.mesh_interface + ' channel ' + self.channel
             if self.test:
-                print "NetworkConfiguration.set_ip() command to set the channel: %s" % command
+                logging.debug("NetworkConfiguration.set_ip() command to set the channel: %s", command)
             else:
                 os.popen(command)
                 time.sleep(1)
@@ -500,7 +500,7 @@ class NetworkConfiguration(object):
             command = '/sbin/iwconfig ' + self.mesh_interface
             configuration = ''
             if self.test:
-                print "NetworkConfiguration.set_ip()command to capture the current state of a network interface: %s" % command
+                logging.debug("NetworkConfiguration.set_ip()command to capture the current state of a network interface: %s", command)
             else:
                 output = os.popen(command)
                 configuration = output.readlines()
@@ -564,7 +564,7 @@ class NetworkConfiguration(object):
         command = '/sbin/ifconfig ' + self.mesh_interface + ' ' + self.mesh_ip
         command = command + ' netmask ' + self.mesh_netmask + ' up'
         if self.test:
-            print "NetworkConfiguration.set_ip()command to set the IP configuration of the mesh interface: %s" % command
+            logging.debug("NetworkConfiguration.set_ip()command to set the IP configuration of the mesh interface: %s", command)
         else:
             os.popen(command)
         time.sleep(5)
@@ -573,7 +573,7 @@ class NetworkConfiguration(object):
         logging.debug("Adding client interface.")
         command = '/sbin/ifconfig ' + self.client_interface + ' ' + self.client_ip + ' up'
         if self.test:
-            print "NetworkConfiguration.set_ip()command to set the IP configuration of the client interface: %s" % command
+            logging.debug("NetworkConfiguration.set_ip()command to set the IP configuration of the client interface: %s", command)
         else:
             os.popen(command)
 
@@ -595,7 +595,7 @@ class NetworkConfiguration(object):
                                  '-d' ]
         captive_portal_return = 0
         if self.test:
-            print "NetworkConfiguration.set_ip() command to start the captive portal daemon: %s" % captive_portal_daemon
+            logging.debug("NetworkConfiguration.set_ip() command to start the captive portal daemon: %s", captive_portal_daemon)
             captive_portal_return = 6
         else:
             captive_portal_return = subprocess.Popen(captive_portal_daemon)
@@ -642,7 +642,7 @@ class NetworkConfiguration(object):
 
             logging.debug("value of portal_pid is %s.", portal_pid)
             if self.test:
-                print "Faking PID of captive_portal.py."
+                logging.debug("Faking PID of captive_portal.py.")
                 portal_pid = "Insert clever PID for captive_portal.py here."
 
             if not portal_pid:
@@ -683,14 +683,14 @@ class NetworkConfiguration(object):
         # See if the /etc/hosts.mesh backup file exists.  If it does, delete it.
         old_hosts_file = self.hosts_file + '.bak'
         if self.test:
-            print "Deleted old /etc/hosts.mesh.bak."
+            logging.debug("Deleted old /etc/hosts.mesh.bak.")
         else:
             if os.path.exists(old_hosts_file):
                 os.remove(old_hosts_file)
 
         # Back up the old hosts.mesh file.
         if self.test:
-            print "Renamed /etc/hosts.mesh file to /etc/hosts.mesh.bak."
+            logging.debug("Renamed /etc/hosts.mesh file to /etc/hosts.mesh.bak.")
         else:
             if os.path.exists(self.hosts_file):
                 os.rename(self.hosts_file, old_hosts_file)
@@ -704,7 +704,7 @@ class NetworkConfiguration(object):
 
         # Generate the contents of the new hosts.mesh file.
         if self.test:
-            print "Pretended to generate new /etc/hosts.mesh file."
+            logging.debug("Pretended to generate new /etc/hosts.mesh file.")
             return
         else:
             hosts = open(self.hosts_file, "w")
@@ -741,15 +741,15 @@ class NetworkConfiguration(object):
         # If an include file already exists, move it out of the way.
         oldfile = self.dnsmasq_include_file + '.bak'
         if self.test:
-            print "Deleting old /etc/dnsmasq.conf.include.bak file."
+            logging.debug("Deleting old /etc/dnsmasq.conf.include.bak file.")
         else:
             if os.path.exists(oldfile):
                 os.remove(oldfile)
 
         # Back up the old dnsmasq.conf.include file.
         if self.test:
-            print "Backing up /etc/dnsmasq.conf.include file."
-            print "Now returning to save time."
+            logging.debug("Backing up /etc/dnsmasq.conf.include file.")
+            logging.debug("Now returning to save time.")
             return
         else:
             if os.path.exists(self.dnsmasq_include_file):

--- a/control_panel/networkconfiguration.py
+++ b/control_panel/networkconfiguration.py
@@ -408,11 +408,11 @@ class NetworkConfiguration(object):
         # Deactivate the interface as if it was down to begin with.
         if not len(result):
             logging.debug("Deactivating wireless interface.")
-            command = '/sbin/ifconfig ' + self.mesh_interface + ' down'
+            command = ['/sbin/ifconfig', self.mesh_interface, 'down']
             if self.test:
                 logging.debug("NetworkConfiguration.tcpip() command to deactivate a mesh interface: %s", command)
             else:
-                os.popen(command)
+                subprocess.popen(command)
 
         # Close the database connection.
         connection.close()
@@ -446,11 +446,11 @@ class NetworkConfiguration(object):
         # network interface.  Full steam ahead, damn the torpedoes!
         # First, take the wireless NIC offline so its mode can be changed.
         logging.debug("Deactivating wireless interface.")
-        command = '/sbin/ifconfig ' + self.mesh_interface + ' down'
+        command = ['/sbin/ifconfig', self.mesh_interface, 'down']
         if self.test:
             logging.debug("NetworkConfiguration.set_ip() command to deactivate a wireless interface: %s", command)
         else:
-            os.popen(command)
+            subprocess.popen(command)
         time.sleep(5)
 
         # Wrap this whole process in a loop to ensure that stubborn wireless
@@ -462,38 +462,38 @@ class NetworkConfiguration(object):
 
             # Set wireless interface mode.
             logging.debug("Configuring wireless interface for ad-hoc mode.")
-            command = '/sbin/iwconfig ' + self.mesh_interface + ' mode ad-hoc'
+            command = ['/sbin/iwconfig', self.mesh_interface, 'mode ad-hoc']
             if self.test:
                 logging.debug("NetworkConfiguration.set_ip() command to activate ad-hoc mode: %s", command)
             else:
-                os.popen(command)
+                subprocess.popen(command)
                 time.sleep(1)
 
             # Set ESSID.
             logging.debug("Configuring ESSID of wireless interface.")
-            command = '/sbin/iwconfig ' + self.mesh_interface + ' essid ' + self.essid
+            command = ['/sbin/iwconfig', self.mesh_interface, 'essid', self.essid]
             if self.test:
                 logging.debug("NetworkConfiguration.set_ip() command to set the ESSID: %s", command)
             else:
-                os.popen(command)
+                subprocess.popen(command)
                 time.sleep(1)
 
             # Set BSSID.
             logging.debug("Configuring BSSID of wireless interface.")
-            command = '/sbin/iwconfig ' + self.mesh_interface + ' ap ' + self.bssid
+            command = ['/sbin/iwconfig', self.mesh_interface, 'ap', self.bssid]
             if self.test:
                 logging.debug("NetworkConfiguration.set_ip() command to set the BSSID: %s", command)
             else:
-                os.popen(command)
+                subprocess.popen(command)
                 time.sleep(1)
 
             # Set wireless channel.
             logging.debug("Configuring channel of wireless interface.")
-            command = '/sbin/iwconfig ' + self.mesh_interface + ' channel ' + self.channel
+            command = ['/sbin/iwconfig', self.mesh_interface, 'channel', self.channel]
             if self.test:
                 logging.debug("NetworkConfiguration.set_ip() command to set the channel: %s", command)
             else:
-                os.popen(command)
+                subprocess.popen(command)
                 time.sleep(1)
 
             # Run iwconfig again and capture the current wireless configuration.
@@ -561,21 +561,21 @@ class NetworkConfiguration(object):
 
         # Call ifconfig and set up the network configuration information.
         logging.debug("Setting IP configuration information on wireless interface.")
-        command = '/sbin/ifconfig ' + self.mesh_interface + ' ' + self.mesh_ip
-        command = command + ' netmask ' + self.mesh_netmask + ' up'
+        command = ['/sbin/ifconfig', self.mesh_interface, self.mesh_ip,
+                   'netmask', self.mesh_netmask, 'up']
         if self.test:
             logging.debug("NetworkConfiguration.set_ip()command to set the IP configuration of the mesh interface: %s", command)
         else:
-            os.popen(command)
+            subprocess.popen(command)
         time.sleep(5)
 
         # Add the client interface.
         logging.debug("Adding client interface.")
-        command = '/sbin/ifconfig ' + self.client_interface + ' ' + self.client_ip + ' up'
+        command = ['/sbin/ifconfig', self.client_interface, self.client_ip, 'up']
         if self.test:
             logging.debug("NetworkConfiguration.set_ip()command to set the IP configuration of the client interface: %s", command)
         else:
-            os.popen(command)
+            subprocess.popen(command)
 
         # Commit the interface's configuration to the database.
         connection = sqlite3.connect(self.netconfdb)

--- a/control_panel/services.py
+++ b/control_panel/services.py
@@ -28,7 +28,7 @@ class Services(object):
     
         # Database used to store states of services and webapps.
         
-        if test:
+        if self.test:
             self.servicedb = 'var/db/controlpanel/services.sqlite'
         else:
             self.servicedb = '/var/db/controlpanel/services.sqlite'

--- a/control_panel/status.py
+++ b/control_panel/status.py
@@ -11,6 +11,7 @@ import logging
 import os
 import os.path
 import sqlite3
+import subprocess
 
 # Import control panel modules.
 # from control_panel import *
@@ -186,14 +187,14 @@ class Status(object):
 
                 # For every mesh interface found in the database, get its
                 # current IP address with ifconfig.
-                command = '/sbin/ifconfig ' + mesh_interface
+                command = ['/sbin/ifconfig', mesh_interface]
                 if self.test:
                     print "TEST: Status.index() command to pull the configuration of a mesh interface:"
                     print command
                 else:
                     logging.debug("Running ifconfig to collect configuration of interface %s.", mesh_interface)
 
-                    output = os.popen(command)
+                    output = subprocess.Popen(command, stdout=subprocess.PIPE).stdout
                     configuration = output.readlines()
                     logging.debug("Output of ifconfig:")
                     logging.debug(configuration)
@@ -227,14 +228,14 @@ class Status(object):
             for client_interface in result:
                 # For every client interface found, run ifconfig and pull
                 # its configuration information.
-                command = '/sbin/ifconfig ' + client_interface[0]
+                command = ['/sbin/ifconfig', client_interface[0]]
                 if self.test:
                     print "TEST: Status.index() command to pull the configuration of a client interface:"
                     print command
                 else:
                     logging.debug("Running ifconfig to collect configuration of interface %s.", client_interface)
 
-                    output = os.popen(command)
+                    output = subprocess.Popen(command, stdout=subprocess.PIPE).stdout
                     configuration = output.readlines()
                     logging.debug("Output of ifconfig:")
                     logging.debug(configuration)
@@ -250,13 +251,13 @@ class Status(object):
                 # associated arp table to count the number of clients currently
                 # associated.  Note that one has to be subtracted from the
                 # count of rows to account for the line of column headers.
-                command = '/sbin/arp -n -i ' + client_interface[0]
+                command = ['/sbin/arp', '-n', '-i', client_interface[0]]
                 if self.test:
                     print "TEST: Status.index() command to dump the ARP table of interface %s: " % client_interface
                     print command
                 else:
                     logging.debug("Running arp to dump the ARP table of client interface %s.", client_interface)
-                    output = os.popen(command)
+                    output = subprocess.Popen(command, stdout=subprocess.PIPE).stdout
                     arp_table = output.readlines()
                     logging.debug("Contents of ARP table:")
                     logging.debug(arp_table)

--- a/service_directory/_services.py
+++ b/service_directory/_services.py
@@ -7,11 +7,11 @@ A module that reads the database of services running on the node and those found
 
 __author__ = 'haxwithaxe (me at haxwithaxe dot net)'
 
-from _utils import *
+import _utils
 import sqlite3
 
 # grab shared config
-conf = config()
+conf = _utils.Config()
 
 def get_local_services_list():
 	'''
@@ -22,23 +22,23 @@ def get_local_services_list():
 	service_list = []
 
 	# Set up a connection to the database.
-	debug("DEBUG: Opening service database.",5)
+	_utils.debug("DEBUG: Opening service database.",5)
 	connection = sqlite3.connect(servicedb)
 	cursor = connection.cursor()
 
 	# Pull a list of running web apps on the node.
-	debug("DEBUG: Getting list of running webapps from database.",5)
+	_utils.debug("DEBUG: Getting list of running webapps from database.",5)
 	cursor.execute("SELECT name FROM webapps WHERE status='active';")
 	results = cursor.fetchall()
 	for service in results:
 		service_list += [{'name':service[0],'path':'/'+service[0],'description':''}]
 
 	# Pull a list of daemons running on the node. This means that most of the web apps users will access will be displayed.
-	debug("DEBUG: Getting list of running servers from database.",5)
+	_utils.debug("DEBUG: Getting list of running servers from database.",5)
 	cursor.execute("SELECT name FROM daemons WHERE status='active' AND showtouser='yes';")
 	results = cursor.fetchall()
 	for service in results:
-		debug("DEBUG: Value of service: %s" % str(service))
+		_utils.debug("DEBUG: Value of service: %s" % str(service))
 		if service[0] in conf.service_info:
 			path = conf.service_info[service[0]]
 		else:
@@ -46,7 +46,7 @@ def get_local_services_list():
 		service_list += [{'name':service[0],'path':path,'description':''}]
 
 		# Clean up after ourselves.
-		debug("DEBUG: Closing service database.",5)
+		_utils.debug("DEBUG: Closing service database.",5)
 		cursor.close()
 	return service_list
 
@@ -83,4 +83,4 @@ def get_services_list():
 	return local_srvc + remote_srvc
 
 if __name__ == '__main__':
-	debug(get_services_list(),0)
+	_utils.debug(get_services_list(),0)

--- a/service_directory/_utils.py
+++ b/service_directory/_utils.py
@@ -38,7 +38,7 @@ def json2file(obj, file_name, mode = 'w'):
 		debug(type_e,5)
 		return False
 
-class Config:
+class Config(object):
 	''' Make me read from a file '''
 	def __init__(self):
 		self.services_cache = '/tmp/byz_services.json'

--- a/service_directory/_utils.py
+++ b/service_directory/_utils.py
@@ -38,7 +38,7 @@ def json2file(obj, file_name, mode = 'w'):
 		debug(type_e,5)
 		return False
 
-class config:
+class Config:
 	''' Make me read from a file '''
 	def __init__(self):
 		self.services_cache = '/tmp/byz_services.json'

--- a/service_directory/avahiclient.py
+++ b/service_directory/avahiclient.py
@@ -3,9 +3,9 @@ import json
 import sys
 import os
 import pybonjour
-from _utils import *
+import _utils
 
-conf = config()
+conf = Config()
 
 SERVICE_TYPE = '__byz__._tcp'
 
@@ -16,17 +16,17 @@ def update_services_cache(service,action = 'add'):
 	print(service)
 	print('updating cache')
 	if os.path.exists(conf.services_cache):
-		services = json.loads(file2str(conf.services_cache))
+		services = json.loads(_utils.file2str(conf.services_cache))
 	else:
 		services = {}
 
 	if action.lower() == 'add':
 		services.update(service)
-		debug('Service added')
+		_utils.debug('Service added')
 	elif action.lower() == 'del' and service in services:
 		del services[service]
-		debug('Service removed')
-	str2file(json.dumps(services),conf.services_cache)
+		_utils.debug('Service removed')
+	_utils.str2file(json.dumps(services),conf.services_cache)
 
 def resolve_callback(sdRef, flags, interfaceIndex, errorCode, fullname, hosttarget, port, txtRecord):
 	if errorCode == pybonjour.kDNSServiceErr_NoError:
@@ -50,7 +50,7 @@ def browse_callback(sdRef, flags, interfaceIndex, errorCode, serviceName, regtyp
 		while not resolved:
 			ready = select.select([resolve_sdRef], [], [], timeout)
 			if resolve_sdRef not in ready[0]:
-				debug('Resolve timed out',1)
+				_utils.debug('Resolve timed out',1)
 				break
 			pybonjour.DNSServiceProcessResult(resolve_sdRef)
 		else:

--- a/service_directory/services.py
+++ b/service_directory/services.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 
 import _services
-from _utils import *
+import _utils
 
-conf = config()
+conf = _utils.Config()
 
 def main():
-	service_entry = file2str('tmpl/services_entry.tmpl')
-	page = file2str('tmpl/services_page.tmpl')
+	service_entry = _utils.file2str('tmpl/services_entry.tmpl')
+	page = _utils.file2str('tmpl/services_page.tmpl')
 	services_list = _services.get_services_list()
 	if len(services_list) < 1:
 		page = page % {'service-list':conf.no_services_msg}


### PR DESCRIPTION
Things done:
- More removals of "from foo import *"
- Standardized on subprocess.Popen
- Now just use logging.debug for debug and test messages
- Captive portal now redirects to the ip address of wlan0:1 - the error_page_404 function doesn't take self, and has standardized arguments so we can't pass in self.args.address (we could fix this if we wanted to move from argparse to gflags since gflags keeps the command line flag values universally accessible)
- Other minor cleanup as seen fit

Cheers!
