### PR TITLE
Merge more changes for v0.3a.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,29 @@
-# ANNOUNCING BYZANTIUM LINUX V0.2a (Bath Salts)
+# ANNOUNCING BYZANTIUM LINUX V0.3a (Beach Cat)
 ### Approved for: GENERAL RELEASE, DISTRIBUTION UNLIMITED
 
-Project Byzantium, a working group of HacDC (http://hacdc.org/) is proud to announce the release of v0.2 alpha of Byzantium Linux, a live distribution of Linux which makes it fast and easy to construct an ad-hoc wireless mesh network which can augment or replace the current telecommunications infrastructure in the event that it is knocked offline (for example, due to a natural disaster) or rendered untrustworthy (through widespread surveillance or disconnection by hostile entities).
+Project Byzantium, a working group of HacDC (http://hacdc.org/) is proud to announce the release of v0.3 alpha of Byzantium Linux, a live distribution of Linux which makes it fast and easy to construct an ad-hoc wireless mesh network which can augment or replace the current telecommunications infrastructure in the event that it is knocked offline (for example, due to a natural disaster) or rendered untrustworthy (through widespread surveillance or disconnection by hostile entities). This release was developed in the days following Hurricane Sandy, and was perfected while the core development team was assisting with disaster relief efforts in the Red Hook neighborhood of New York City in November of 2012.
 
-Byzantium Linux is designed to run on any x86 computer with at least one 802.11 a/b/g/n wireless interface. Byzantium can be burned to a CD- or DVD-ROM (the .iso image is around 460 megabytes in size), booted from an external hard drive, or can even be installed in parallel with an existing operating system without risk to the user's data and software. Byzantium Linux will act as a node of the mesh and will automatically connect to other mesh nodes and act as an access point for wifi-enabled mobile devices.
+Byzantium Linux is designed to run on any x86 computer with at least one 802.11 a/b/g/n wireless interface. Byzantium can be burned to a CD- or DVD-ROM (the .iso image is around 300 megabytes in size), booted from an external hard drive, or can even be installed in parallel with an existing operating system without risk to the user's data and software. Byzantium Linux will act as a node of the mesh and will automatically connect to other mesh nodes and act as an access point for wifi-enabled mobile devices. This release of Byzantium Linux also incorporates seamless interoperability with mesh networks constructed using the Commotion Wireless (https://commotionwireless.net/) firmware.
 
-**THIS IS AN ALPHA RELEASE!** Do *NOT* expect Byzantium to be perfect. Some features are not ready yet, others need work. Things are going to break in weird ways and we need to know what those ways are so we can fix them. Please, for the love of LOLcats, do not deploy Byzantium in situations where lives are at stake.
+**THIS IS AN ALPHA RELEASE!**
+Do *NOT* expect Byzantium to be perfect. Some features are not ready yet, others need work. Things are going to break in weird ways and we need to know what those ways are so we can fix them. Please, for the love of LOLcats, do not deploy Byzantium in situations where lives are at stake.
+
+**THIS IS ALSO A VERY SPECIAL RELEASE!**
+We built this release in the days following Hurricane Sandy and deployed it in New York City. We've streamlined it a lot - the web-based control panel was removed; so were the network applications.  This release was designed to be lean and mean, providing only the bare essentials (the ability to set up a wireless mesh network, and the ability to connect that mesh to the global Net if possible). Those applications will return in a future release in a very different form.  This version was designed to require as little user interaction as possible and will automatically configure itself. Once Byzantium Linux is online it is a fully operational mesh node.
 
 #### FEATURES:
 - Binary compatible with Slackware-CURRENT. Existing Slackware packages can be converted with a single command.
 - Can act as a gateway to the Internet if a link is available (via Ethernet or tethered smartphone).
-- Linux kernel v3.1.8
+- Linux kernel v3.3.4
 - Drivers for dozens of wireless chipsets
-- KDE Trinity v3.5.12
+- KDE Trinity R14.0.0
 - LXDE (2010 release of all components)
 - Mplayer
 - GCC v4.5.2
-- Perl v5.12.3
-- Python v2.6.6
-- Firefox v4.0.1
+- Perl v5.14
+- Python v2.7.3
+- Firefox v13.0.1
 - X.org
-- Custom web-based control panel
 
 #### SYSTEM REQUIREMENTS:
 ##### To Use
@@ -40,7 +43,7 @@ Byzantium Linux is designed to run on any x86 computer with at least one 802.11 
 - Developers!
 - DEVELOPERS!
 - No more Bill Ballmer impersonations.
-- People running Byzantium to find bugs.
+- People testing Byzantium to find bugs.
 - People reporting bugs on our Github page (https://github.com/Byzantium/Byzantium/issues). We can't fix what we don't know about!
 - Patches.
 - People booting Byzantium and setting up small meshes (2-5 clients) to tell us how well it works for you with your hardware. We have a hardware compatibility list on our wiki that needs to be expanded.

--- a/porteus/home/guest/.passfail/failure.html
+++ b/porteus/home/guest/.passfail/failure.html
@@ -66,7 +66,8 @@
         USB wireless devices so chances are our driver kit will detect and configure it.  When you have time later
         <a href="https://github.com/Byzantium/Byzantium/issues">please file a trouble ticket</a> and we'll fix it in the next release.</p>
         <p class="lead">Regardless, you have a fully functional desktop at your fingertips, so you can plug USB drives in, copy and edit
-        files, and do other workstation things.  You can also plug mobile devices into this computer to recharge them.</p>
+        files, and do other workstation things (just click the icon in the bottom-left corner).  You can also plug mobile devices into
+        this computer to recharge them.</p>
 
       </div>
 

--- a/porteus/home/guest/.passfail/success.html
+++ b/porteus/home/guest/.passfail/success.html
@@ -61,7 +61,7 @@
         <h1>Your Byzantium node is online!</h1>
         <p class="lead">Byzantium Linux has automatically configured itself, so you don't have to do anything else.</p>
         <p class="lead">No, really, you just set up a mesh node.  This is all you have to do.</p>
-        <p class="lead">However, you also have a fully functional desktop at your fingertips.
+        <p class="lead">However, you also have a fully functional desktop at your fingertips, just click the icon in the bottom-left corner.
         You can also plug mobile devices into this node to recharge them, and if you plug a network cable into
         the appropriate jack this node will turn itself into a gateway for the rest of the mesh.</p>
         <p class="lead">Also, Byzantium is now fully compatible with <a href="https://commotionwireless.net/">Commotion Wireless</a>,

--- a/verify_operation.sh
+++ b/verify_operation.sh
@@ -52,9 +52,9 @@ if [ ! $FAKEDNS_PID ]; then
 # Depending on whether or not everything started up properly, run Firefox with
 # one of two HTML files as arguments.
 if [ $SUCCESS ]; then
-    firefox .passfail/success.html &
+    firefox ~/.passfail/success.html &
 else
-    firefox .passfail/failure.html &
+    firefox ~/.passfail/failure.html &
 fi
 
 # End.


### PR DESCRIPTION
These are yet more changes that make v0.3a what it is.  Among them are fixes to the [success,failure].html pages as well as the script that tests the state of the system, a new README.md file, and some other tweaks.

Unfortunately, the bootsplash screen still doesn't work.  I'm going to fix that next.
