### PR TITLE
Fixed a bug in the "Did it blend?" script.

### DIFF
--- a/verify_operation.sh
+++ b/verify_operation.sh
@@ -38,7 +38,7 @@ if [ ! $CP_PID ]; then
     fi
 
 # Test to see if the dead client reaper started.
-MUDC_PID=`ps ax | grep [c]aptive_portal | awk '{print $1}'`
+MUDC_PID=`ps ax | grep [m]op_up_dead_clients | awk '{print $1}'`
 if [ ! $MUDC_PID ]; then
     SUCCESS=""
     fi


### PR DESCRIPTION
There was a bug in the "Did it blend?" script in which it wasn't correctly detecting the dead client reaper after system start.  This fix was rewritten and tested it in a VM, and it works.
