### PR TITLE
Small typo in byzantium_configd.py

### DIFF
--- a/byzantium_configd.py
+++ b/byzantium_configd.py
@@ -70,7 +70,7 @@ for i in interfaces:
 
 # Find unused IP addresses to configure this node's interfaces with.
 for interface in wireless:
-    print "Attepting to configure interface %s." % interface
+    print "Attempting to configure interface %s." % interface
 
     # Turn down the interface.
     command = ['/sbin/ifconfig', interface, 'down']


### PR DESCRIPTION
Just caught a small typo while I was reading through the automatic configuration script.
