### PR TITLE
Quick change to one of the passfail html pages

### DIFF
--- a/porteus/home/guest/.passfail/failure.html
+++ b/porteus/home/guest/.passfail/failure.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>Your Byzantium node is online!</title>
+    <title>Something went wrong.</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="If the user sees this page, it means that Byzantium Linux did not successfully configure itself.">
     <meta name="author" content="The Doctor" >


### PR DESCRIPTION
Title was the same in both. failure.html now says "Something went wrong" in the page title.
